### PR TITLE
Better folder lookup for other shader repos and better folder scheme for external shaders

### DIFF
--- a/reshade-linux.sh
+++ b/reshade-linux.sh
@@ -399,12 +399,26 @@ if [[ -n $SHADER_REPOS ]]; then
             done
         fi
     done
+    echo "Checking for External Shader updates."
     if [[ $MERGE_SHADERS == 1 ]] && [[ -d "$MAIN_PATH/External_shaders" ]]; then
-        cd "$MAIN_PATH/External_shaders" || exit
-        for file in *; do
-            [[ ! -f $file ]] && continue
-            [[ -L "$MAIN_PATH/ReShade_shaders/Merged/Shaders/$file" ]] && continue
-            ln -s "$(realpath "$MAIN_PATH/External_shaders/$file")" "$MAIN_PATH/ReShade_shaders/Merged/Shaders/"
+        for dirName in Shaders Textures; do
+            [[ ! -d "$MAIN_PATH/External_shaders/$dirName" ]] && continue
+            cd "$MAIN_PATH/External_shaders/$dirName" || continue
+            for file in *; do
+                [[ ! -f $file ]] && continue
+                [[ -L "$MAIN_PATH/ReShade_shaders/Merged/$dirName/$file" ]] && continue
+                ln -s "$(realpath "$MAIN_PATH/External_shaders/$dirName/$file")" "$MAIN_PATH/ReShade_shaders/Merged/$dirName/"
+            done
+            for dir in $(find . -type d); do
+                [[ ! -d "$MAIN_PATH/External_shaders/$dirName/$dir" ]] && continue
+                [[ ! -d "$MAIN_PATH/ReShade_shaders/Merged/$dirName/$dir" ]] && mkdir -p "$MAIN_PATH/ReShade_shaders/Merged/$dirName/$dir"
+                cd "$MAIN_PATH/External_shaders/$dirName/$dir" || continue
+                for file in *; do
+                    [[ ! -f $file ]] && continue
+                    [[ -L "$MAIN_PATH/ReShade_shaders/Merged/$dirName/$dir/$file" ]] && continue
+                    ln -s "$(realpath "$MAIN_PATH/External_shaders/$dirName/$dir/$file")" "$MAIN_PATH/ReShade_shaders/Merged/$dirName/$dir/"
+                done
+            done
         done
     fi
 fi

--- a/reshade-linux.sh
+++ b/reshade-linux.sh
@@ -378,12 +378,23 @@ if [[ -n $SHADER_REPOS ]]; then
         fi
         if [[ $MERGE_SHADERS == 1 ]]; then
             for dirName in Shaders Textures; do
-                [[ ! -d "$MAIN_PATH/ReShade_shaders/$localRepoName/$dirName" ]] && continue
-                cd "$MAIN_PATH/ReShade_shaders/$localRepoName/$dirName" || continue
+                dirPath=$(find "$MAIN_PATH/ReShade_shaders/$localRepoName" -type d -name "$dirName")
+                [[ ! -n "$dirPath" ]] && continue
+                cd "$dirPath" || continue
                 for file in *; do
                     [[ ! -f $file ]] && continue
                     [[ -L "$MAIN_PATH/ReShade_shaders/Merged/$dirName/$file" ]] && continue
-                    ln -s "$(realpath "$MAIN_PATH/ReShade_shaders/$localRepoName/$dirName/$file")" "$MAIN_PATH/ReShade_shaders/Merged/$dirName/"
+                    ln -s "$(realpath "$dirPath/$file")" "$MAIN_PATH/ReShade_shaders/Merged/$dirName/"
+                done
+                for anyDir in $(find . -type d); do
+                    [[ ! -d "$dirPath/$anyDir" ]] && continue
+                    [[ ! -d "$MAIN_PATH/ReShade_shaders/Merged/$dirName/$anyDir" ]] && mkdir -p "$MAIN_PATH/ReShade_shaders/Merged/$dirName/$anyDir"
+                    cd "$dirPath/$anyDir" || continue
+                    for file in *; do
+                        [[ ! -f $file ]] && continue
+                        [[ -L "$MAIN_PATH/ReShade_shaders/Merged/$dirName/$anyDir/$file" ]] && continue
+                        ln -s "$(realpath "$dirPath/$anyDir/$file")" "$MAIN_PATH/ReShade_shaders/Merged/$dirName/$anyDir/"
+                    done
                 done
             done
         fi


### PR DESCRIPTION
The current "Shaders" and "Textures" folder/directory lookup for each repos are still pretty barebone and assume those folders are available at the root. I've encountered repos that have their "Shaders" folder inside of another folder first (e.g: crt-royale), so I modified the lookup to search for the actual path in any of the subfolder.

Other repos also have additional folders inside their "Shaders" (e.g: Insane shaders), so I modified the lookup to also link to those folders.

As with the external shaders, I modified it to use the basic Shaders+Textures folder scheme, since a lot of non-repo shaders also have their textures (e.g: quint rtgi, regrade).

I only modified the shell script since I'm testing this on linux.